### PR TITLE
configure github site maven plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Parent POM
+# Parent POM
 
  - __Build Status:__ [![Build Status](https://travis-ci.com/mathieucarbou/parent-pom.png?branch=master)](https://travis-ci.com/mathieucarbou/parent-pom)
  - __Issues:__ https://github.com/mathieucarbou/parent-pom/issues
@@ -23,8 +23,9 @@ __Declaration__
 
 ## Maven Sites ##
 
- - [Version 2](https://code.mathieu.photography/parent-pom/reports/2/index.html)
- - [Version 3](https://code.mathieu.photography/parent-pom/reports/3/index.html)
+- - [Version 4](https://mathieucarbou.github.io/index.html)
+- - [Version 3](https://code.mathieu.photography/parent-pom/reports/3/index.html)
+- - [Version 2](https://code.mathieu.photography/parent-pom/reports/2/index.html)
 
 [![githalytics.com alpha](https://cruel-carlota.pagodabox.com/a20ded47d7533f559376e3f026b94f84 "githalytics.com")](http://githalytics.com/mycila/pom)
 
@@ -33,4 +34,46 @@ __Declaration__
 ```
 mvn release:prepare
 mvn release:perform -Darguments="-Dgpg.keyname=EDEA921A"
+```
+
+If some aspects of your project are non-standard, you may override the defaults via either `mvn -Dsome.property` or declaring them in your pom:
+```xml
+<properties>
+    <!-- change this if you deploy to github enterprise instead -->
+    <parameter.site.domain>github.com</parameter.site.domain>
+    <!-- change this if your github org does not match what this parent pom is in -->
+    <parameter.site.subdomain>mathieucarbou</parameter.site.subdomain>
+    <!-- change this if your project's repository is not named the same as the artifactId -->
+    <parameter.site.root.uri>${project.artifactId}</parameter.site.root.uri>
+    <!-- set to true to disable site publishing altogether, bound to site phase by default -->
+    <parameter.site.github.deploy.skip>false</parameter.site.github.deploy.skip>
+    <!-- set to false to enable vanilla site deploy plugin -->
+    <parameter.site.maven.deploy.skip>true</parameter.site.maven.deploy.skip>
+</properties>
+```
+
+First create a [personal access token](https://github.com/settings/tokens/) with the following permissions:
+* public_repo
+* read:enterprise
+* read:org
+* read:user
+* user:email
+
+and a section in your ~/.m2/settings.xml like:
+
+```xml
+    <server>
+      <id>github.com</id>
+      <password>your-token-probably-starting-with 'ghp_'</password>
+    </server>
+```
+
+Now you may run:
+```
+mvn site site-deploy
+```
+
+If you would like to preview a single-module site, you may run:
+```sh
+mvn org.apache.maven.plugins:maven-site-plugin:run
 ```

--- a/pom.xml
+++ b/pom.xml
@@ -27,21 +27,29 @@
     <name>Mycila POM</name>
     <description>Parent POM</description>
     <inceptionYear>2013</inceptionYear>
-    <url>http://mycila.github.io/${mycila.github.name}</url>
+    <url>https://${parameter.site.subdomain}.github.io/${project.artifactId}</url>
 
     <properties>
         <jdk.version>1.8</jdk.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+
         <osgi.private>com.mycila.${mycila.github.name}.internal</osgi.private>
         <osgi.import>*</osgi.import>
         <osgi.export>!com.mycila.${mycila.github.name}.internal*,com.mycila.${mycila.github.name}*;version="${project.version}";-noimport:=true</osgi.export>
-        <mycila.github.name>pom</mycila.github.name>
+        <mycila.github.name>mycila</mycila.github.name>
+
+        <parameter.site.domain>github.com</parameter.site.domain>
+        <parameter.site.subdomain>mathieucarbou</parameter.site.subdomain>
+        <parameter.site.root.uri>${project.artifactId}</parameter.site.root.uri>
+        <parameter.site.github.deploy.skip>false</parameter.site.github.deploy.skip>
+        <parameter.site.maven.deploy.skip>true</parameter.site.maven.deploy.skip>
+        <parameter.site.uri>${parameter.site.subdomain}/${parameter.site.root.uri}/${project.version}/</parameter.site.uri>
     </properties>
 
     <scm>
-        <connection>scm:git:https://github.com/mycila/${mycila.github.name}.git</connection>
-        <developerConnection>scm:git:git@github.com:mycila/${mycila.github.name}.git</developerConnection>
-        <url>http://github.com/mycila/${mycila.github.name}</url>
+        <connection>scm:git:git@${parameter.site.domain}:${parameter.site.subdomain}/${parameter.site.root.uri}.git</connection>
+        <developerConnection>scm:git:git@${parameter.site.domain}:${parameter.site.subdomain}/${parameter.site.root.uri}.git</developerConnection>
+        <url>https://${parameter.site.domain}/${parameter.site.subdomain}/${parameter.site.root.uri}</url>
         <tag>HEAD</tag>
     </scm>
 
@@ -52,12 +60,12 @@
 
     <issueManagement>
         <system>GitHub</system>
-        <url>https://github.com/mycila/${mycila.github.name}/issues</url>
+        <url>https://${parameter.site.domain}/${parameter.site.subdomain}/${parameter.site.root.uri}/issues</url>
     </issueManagement>
 
     <ciManagement>
         <system>Travis</system>
-        <url>https://travis-ci.org/mycila/${mycila.github.name}</url>
+        <url>https://travis-ci.com/${parameter.site.subdomain}/${parameter.site.root.uri}</url>
     </ciManagement>
 
     <developers>
@@ -94,11 +102,46 @@
             <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
             <uniqueVersion>false</uniqueVersion>
         </snapshotRepository>
+        <site>
+            <id>${parameter.site.domain}</id>
+            <name>${parameter.site.domain}</name>
+            <url>scm:git:ssh://git@${parameter.site.domain}/${parameter.site.uri}.git</url>
+        </site>
     </distributionManagement>
 
     <build>
         <pluginManagement>
             <plugins>
+                <plugin>
+                    <groupId>com.github.github</groupId>
+                    <artifactId>site-maven-plugin</artifactId>
+                    <version>0.12</version>
+                    <configuration>
+                        <server>${parameter.site.domain}</server>
+                        <path>${parameter.site.location}</path>
+                        <merge>true</merge>
+                        <message>Updating maven generated documentation for ${project.version}</message>
+                        <skip>${parameter.site.github.deploy.skip}</skip>
+                    </configuration>
+                    <executions>
+                        <execution>
+                            <goals>
+                                <goal>site</goal>
+                            </goals>
+                            <phase>site-deploy</phase>
+                        </execution>
+                    </executions>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-site-plugin</artifactId>
+                    <version>3.9.1</version>
+                    <configuration>
+                        <relativizeDecorationLinks>false</relativizeDecorationLinks>
+                        <attach>false</attach>
+                        <skipDeploy>${parameter.site.maven.deploy.skip}</skipDeploy>
+                    </configuration>
+                </plugin>
                 <plugin>
                     <artifactId>maven-enforcer-plugin</artifactId>
                     <version>1.4.1</version>
@@ -244,8 +287,9 @@
                     </configuration>
                 </plugin>
                 <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-plugin-plugin</artifactId>
-                    <version>3.6.3</version>
+                    <version>3.6.1</version>
                     <configuration>
                         <detail>true</detail>
                         <skipErrorNoDescriptorsFound>true</skipErrorNoDescriptorsFound>
@@ -268,6 +312,26 @@
             </plugins>
         </pluginManagement>
         <plugins>
+            <plugin>
+                <groupId>com.github.github</groupId>
+                <artifactId>site-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-site-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>attach-site-descriptor</id>
+                        <goals>
+                            <goal>attach-descriptor</goal>
+                        </goals>
+                        <inherited>false</inherited>
+                        <configuration>
+                            <attach>true</attach>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
             <plugin>
                 <artifactId>maven-enforcer-plugin</artifactId>
                 <executions>

--- a/src/site/site.xml
+++ b/src/site/site.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/DECORATION/1.3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/DECORATION/1.3.0 http://maven.apache.org/xsd/decoration-1.3.0.xsd">
+    <skin>
+        <groupId>org.apache.maven.skins</groupId>
+        <artifactId>maven-fluido-skin</artifactId>
+        <version>1.9</version>
+    </skin>
+  <body>
+    <menu ref="modules" position="left" inherit="top" />
+    <menu ref="reports" inherit="top" />
+  </body>
+</project>


### PR DESCRIPTION
The readme for https://github.com/mathieucarbou/license-maven-plugin is getting a little unwieldy, and was about to add to its length. We discussed briefly having these as normal maven sites (for plugins it's handy because you get the maven-plugin-plugin generated parameter documentation from the javadocs above the Parameters).

Here's an example of what this looks like: https://rremer.github.io/parent-pom/scm.html

I obviously deployed with alternate parameters so I could show it off, this was my deploy command:
```
mvn -Dparameter.site.subdomain=rremer -Dparameter.site.root.uri=parent-pom site site-deploy --settings /tmp/settings.xml
```

The important bit here is that downstream projects should have to configure anything at all, so if we want to update the parent (post release) in license-maven-plugin, you just do a `mvn site site-deploy`.